### PR TITLE
NEXT-222: Update Reporting V1 Documentation

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -2298,7 +2298,7 @@ paths:
                   accounts: []
         400:
           description: Bad Request. Check the json response for more details on what went wrong.
-      deprecated: false
+      deprecated: true
   /v1/reporting/async_reports:
     get:
       security:
@@ -2339,7 +2339,7 @@ paths:
                 - created_datetime: 2017-02-12T13:30:00
                   last_modified_datetime: 2017-02-12T13:30:00
                 pagination: {}
-      deprecated: false
+      deprecated: true
   '/v1/reporting/async_reports/{report_id}':
     get:
       security:
@@ -2367,8 +2367,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/AsyncReport'
               example:
-                created_datetime: 2017-02-12T13:30:00
-                last_modified_datetime: 2017-02-12T13:30:00
+                id: 762b24ad-9110-42e3-b1d8-6c60a61a7235
+                report_status: DONE
         400:
           description: Bad Request. Check the json response for more details on what went wrong.
         404:
@@ -2406,7 +2406,7 @@ paths:
           description: Bad Request. Check the json response for more details on what went wrong.
         404:
           description: Report not found or not finished.
-      deprecated: false
+      deprecated: true
   /v1/reporting/received_messages/detail/async:
     post:
       security:
@@ -2428,8 +2428,6 @@ paths:
               end_date: 2017-02-10T13:30:00
               start_date: 2017-02-12T13:30:00
               period: TODAY
-              sort_by: ACCOUNT
-              sort_direction: ASCENDING
               timezone: Australia/Melbourne
               accounts: []
               delivery_options:
@@ -2502,13 +2500,6 @@ paths:
         explode: true
         schema:
           $ref: '#/components/schemas/action'
-      - name: destination_address_country
-        in: query
-        description: Filter results by destination address country.
-        style: form
-        explode: true
-        schema:
-          type: string
       - name: destination_address
         in: query
         description: Filter results by destination address.
@@ -2553,27 +2544,6 @@ paths:
         schema:
           type: number
           format: double
-      - name: sort_by
-        in: query
-        description: Field to sort results set by
-        style: form
-        explode: true
-        schema:
-          $ref: '#/components/schemas/sort_by'
-      - name: sort_direction
-        in: query
-        description: Order to sort results by.
-        style: form
-        explode: true
-        schema:
-          $ref: '#/components/schemas/sort_direction'
-      - name: source_address_country
-        in: query
-        description: Filter results by source address country.
-        style: form
-        explode: true
-        schema:
-          type: string
       - name: source_address
         in: query
         description: Filter results by source address.
@@ -2639,8 +2609,6 @@ paths:
               end_date: 2017-02-10T13:30:00
               start_date: 2017-02-12T13:30:00
               period: TODAY
-              sort_by: DELIVERY_REPORT
-              sort_direction: ASCENDING
               timezone: Australia/Melbourne
               accounts: []
               statuses:
@@ -2708,20 +2676,6 @@ paths:
           type: array
           items:
             type: string
-      - name: delivery_report
-        in: query
-        description: Filter results by delivery report.
-        style: form
-        explode: true
-        schema:
-          type: boolean
-      - name: destination_address_country
-        in: query
-        description: Filter results by destination address country.
-        style: form
-        explode: true
-        schema:
-          type: string
       - name: destination_address
         in: query
         description: Filter results by destination address.
@@ -2787,27 +2741,6 @@ paths:
         schema:
           type: number
           format: double
-      - name: sort_by
-        in: query
-        description: Field to sort results set by
-        style: form
-        explode: true
-        schema:
-          $ref: '#/components/schemas/sort_by'
-      - name: sort_direction
-        in: query
-        description: Order to sort results by.
-        style: form
-        explode: true
-        schema:
-          $ref: '#/components/schemas/sort_direction'
-      - name: source_address_country
-        in: query
-        description: Filter results by source address country.
-        style: form
-        explode: true
-        schema:
-          type: string
       - name: source_address
         in: query
         description: Filter results by source address.
@@ -2873,8 +2806,6 @@ paths:
             example:
               end_date: 2017-02-10T13:30:00
               start_date: 2017-02-12T13:30:00
-              summary_by: COUNT
-              summary_field: MESSAGE_ID
               group_by:
               - DAY
               period: THIS_WEEK
@@ -2953,13 +2884,6 @@ paths:
           type: array
           items:
             type: string
-      - name: destination_address_country
-        in: query
-        description: Filter results by destination address country.
-        style: form
-        explode: true
-        schema:
-          type: string
       - name: destination_address
         in: query
         description: Filter results by destination address.
@@ -2984,27 +2908,6 @@ paths:
       - name: metadata_value
         in: query
         description: Filter results for messages that include a metadata key containing this value. If this parameter is provided, the metadata_key parameter must also be provided.
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: summary_by
-        in: query
-        description: Function to apply when summarising results
-        style: form
-        explode: true
-        schema:
-          $ref: '#/components/schemas/summary_by'
-      - name: summary_field
-        in: query
-        description: Field to summarise results by
-        style: form
-        explode: true
-        schema:
-          $ref: '#/components/schemas/summary_field'
-      - name: source_address_country
-        in: query
-        description: Filter results by source address country.
         style: form
         explode: true
         schema:
@@ -3141,20 +3044,6 @@ paths:
           type: array
           items:
             type: string
-      - name: delivery_report
-        in: query
-        description: Filter results by delivery report.
-        style: form
-        explode: true
-        schema:
-          type: boolean
-      - name: destination_address_country
-        in: query
-        description: Filter results by destination address country.
-        style: form
-        explode: true
-        schema:
-          type: string
       - name: destination_address
         in: query
         description: Filter results by destination address.
@@ -3162,20 +3051,6 @@ paths:
         explode: true
         schema:
           type: string
-      - name: summary_by
-        in: query
-        description: Function to apply when summarising results
-        style: form
-        explode: true
-        schema:
-          $ref: '#/components/schemas/summary_by'
-      - name: summary_field
-        in: query
-        description: Field to summarise results by
-        style: form
-        explode: true
-        schema:
-          $ref: '#/components/schemas/summary_field'
       - name: message_format
         in: query
         description: Filter results by message format.
@@ -3200,13 +3075,6 @@ paths:
       - name: status_code
         in: query
         description: Filter results by message status code.
-        style: form
-        explode: true
-        schema:
-          type: string
-      - name: source_address_country
-        in: query
-        description: Filter results by source address country.
         style: form
         explode: true
         schema:
@@ -3331,7 +3199,7 @@ paths:
           description: Data cannot be found
         500:
           description: System Error
-      deprecated: false
+      deprecated: true
   /v1/reporting/links/detail:
     get:
       security:
@@ -3400,7 +3268,7 @@ paths:
           description: Data cannot be found
         500:
           description: System Error
-      deprecated: false
+      deprecated: true
   /v1/webhooks/messages:
     get:
       security:
@@ -5598,8 +5466,6 @@ components:
           type: string
           description: Start date time for report window. By default, the timezone for this parameter will be taken from the account settings for the account associated with the credentials used to make the request, or the account included in the Account parameter. This can be overridden using the timezone parameter per request. The date must be in ISO8601 format.
           example: 2017-02-12T13:30:00
-        sorting:
-          $ref: '#/components/schemas/Sorting'
         filters:
           $ref: '#/components/schemas/Filters'
         timezone:
@@ -5651,23 +5517,11 @@ components:
         id:
           type: string
           description: Unique ID for this reply
-        message_type:
-          $ref: '#/components/schemas/message_type'
-        type:
-          $ref: '#/components/schemas/type'
         report_status:
           $ref: '#/components/schemas/report_status'
-        created_datetime:
-          type: string
-          description: Date time at which this report was created.
-          example: 2017-02-12T13:30:00
-        last_modified_datetime:
-          type: string
-          description: Date time at which this report was last modified.
-          example: 2017-02-12T13:30:00
       example:
-        created_datetime: 2017-02-12T13:30:00
-        last_modified_datetime: 2017-02-12T13:30:00
+        id: 762b24ad-9110-42e3-b1d8-6c60a61a7235
+        report_status: DONE
     ReceivedMessage:
       title: ReceivedMessage
       type: object
@@ -5758,13 +5612,6 @@ components:
           type: string
           description: Content of the message
           example: Hello world!
-        delivered_timestamp:
-          type: string
-          description: If a delivery report was requested for this message, this is the time at which the message was delivered (or failed to be delivered) to the destination address.
-          example: 2017-02-12T13:30:00
-        delivery_report:
-          type: boolean
-          description: Indicates if a delivery report was requested for this message
         destination_address:
           type: string
           description: Address this message was delivered to
@@ -5792,14 +5639,6 @@ components:
           type: string
           description: Country associated with the source address
           example: AU
-        units:
-          type: number
-          description: >-
-            The total number of calculated SMS units this message cost. 1 SMS unit is defined as 160 GSM characters, or 153 GSM characters for multi-part messages as some characters are used to concatenate the message on the receiving handset.
-
-
-            Messages with one or more non-GSM characters will be submitted using UCS-2 encoding. UCS-2 encoding means the message has a maximum of 70 characters per SMS, or 67 characters for multi-part messages.
-          example: 2
         timestamp:
           type: string
           description: Date time at which this message was submitted to the API, refer to the delivered timestamp for the time at which the message was delivered (or failed to be delivered) to the destination address.
@@ -5821,19 +5660,16 @@ components:
         data:
         - account: MyAccount001
           content: Hello world!
-          delivered_timestamp: 2017-02-12T13:30:00
           destination_address: +61491570156
           destination_address_country: AU
           format: AU
           source_address: +61491570156
           source_address_country: AU
-          units: 2
           timestamp: 2017-02-12T13:30:00
         pagination: {}
         properties:
           end_date: 2017-02-10T13:30:00
           start_date: 2017-02-12T13:30:00
-          sorting: {}
           filters:
             accounts: []
           timezone: The timezone that this report is presented in, this may be passed in as a parameter to the report, or taken from account settings
@@ -5885,10 +5721,6 @@ components:
           description: Any filters provided as parameters for this report
         grouping:
           $ref: '#/components/schemas/grouping'
-        summary:
-          $ref: '#/components/schemas/summary'
-        summary_field:
-          $ref: '#/components/schemas/summary_field'
         timezone:
           type: string
           example: The timezone that this report is presented in, this may be passed in as a parameter to the report, or taken from account settings
@@ -5921,6 +5753,7 @@ components:
       required:
       - end_date
       - start_date
+      - delivery_options
       type: object
       properties:
         end_date:
@@ -5933,10 +5766,6 @@ components:
           example: 2017-02-12T13:30:00
         period:
           $ref: '#/components/schemas/period'
-        sort_by:
-          $ref: '#/components/schemas/sort_by'
-        sort_direction:
-          $ref: '#/components/schemas/sort_direction'
         timezone:
           type: string
           description: The timezone to use for the context of the request. If provided this will be used as the timezone for the start date and end date parameters, and all datetime fields returns in the response. The timezone should be provided as a IANA (Internet Assigned Numbers Authority) time zone database zone name, i.e., 'Australia/Melbourne'.
@@ -5953,9 +5782,6 @@ components:
 
 
             credentials and all sub accounts.
-        destination_address_country:
-          type: string
-          description: Filter results by destination address country.
         destination_address:
           type: string
           description: Filter results by destination address.
@@ -5967,9 +5793,6 @@ components:
         metadata_value:
           type: string
           description: Filter results for messages that include a metadata key containing this value. If this parameter is provided, the metadata_key parameter must also be provided.
-        source_address_country:
-          type: string
-          description: Filter results by source address country.
         source_address:
           type: string
           description: Filter results by source address.
@@ -5997,6 +5820,7 @@ components:
       required:
       - end_date
       - start_date
+      - delivery_options
       type: object
       properties:
         end_date:
@@ -6009,10 +5833,6 @@ components:
           example: 2017-02-12T13:30:00
         period:
           $ref: '#/components/schemas/period'
-        sort_by:
-          $ref: '#/components/schemas/sort_by'
-        sort_direction:
-          $ref: '#/components/schemas/sort_direction'
         timezone:
           type: string
           description: The timezone to use for the context of the request. If provided this will be used as the timezone for the start date and end date parameters, and all datetime fields returns in the response. The timezone should be provided as a IANA (Internet Assigned Numbers Authority) time zone database zone name, i.e., 'Australia/Melbourne'.
@@ -6029,9 +5849,6 @@ components:
 
 
             credentials and all sub accounts.
-        destination_address_country:
-          type: string
-          description: Filter results by destination address country.
         destination_address:
           type: string
           description: Filter results by destination address.
@@ -6043,9 +5860,6 @@ components:
         metadata_value:
           type: string
           description: Filter results for messages that include a metadata key containing this value. If this parameter is provided, the metadata_key parameter must also be provided.
-        source_address_country:
-          type: string
-          description: Filter results by source address country.
         source_address:
           type: string
           description: Filter results by source address.
@@ -6059,9 +5873,6 @@ components:
         status_code:
           type: string
           description: Filter results by message status code.
-        delivery_report:
-          type: boolean
-          description: Filter results by delivery report.
         delivery_options:
           type: array
           items:
@@ -6071,8 +5882,6 @@ components:
         end_date: 2017-02-10T13:30:00
         start_date: 2017-02-12T13:30:00
         period: TODAY
-        sort_by: DELIVERY_REPORT
-        sort_direction: ASCENDING
         timezone: Australia/Melbourne
         accounts: []
         statuses:
@@ -6086,6 +5895,7 @@ components:
       required:
       - end_date
       - start_date
+      - delivery_options
       type: object
       properties:
         end_date:
@@ -6096,10 +5906,6 @@ components:
           type: string
           description: Start date time for report window. By default, the timezone for this parameter will be taken from the account settings for the account associated with the credentials used to make the request, or the account included in the Account parameter. This can be overridden using the timezone parameter per request. The date must be in ISO8601 format.
           example: 2017-02-12T13:30:00
-        summary_by:
-          $ref: '#/components/schemas/summary_by'
-        summary_field:
-          $ref: '#/components/schemas/summary_field'
         group_by:
           type: array
           items:
@@ -6123,9 +5929,6 @@ components:
 
 
             credentials and all sub accounts.
-        destination_address_country:
-          type: string
-          description: Filter results by destination address country.
         destination_address:
           type: string
           description: Filter results by destination address.
@@ -6137,9 +5940,6 @@ components:
         metadata_value:
           type: string
           description: Filter results for messages that include a metadata key containing this value. If this parameter is provided, the metadata_key parameter must also be provided.
-        source_address_country:
-          type: string
-          description: Filter results by source address country.
         source_address:
           type: string
           description: Filter results by source address.
@@ -6153,8 +5953,6 @@ components:
       example:
         end_date: 2017-02-10T13:30:00
         start_date: 2017-02-12T13:30:00
-        summary_by: COUNT
-        summary_field: MESSAGE_ID
         group_by:
         - DAY
         period: THIS_WEEK
@@ -6179,10 +5977,6 @@ components:
           type: string
           description: Start date time for report window. By default, the timezone for this parameter will be taken from the account settings for the account associated with the credentials used to make the request, or the account included in the Account parameter. This can be overridden using the timezone parameter per request. The date must be in ISO8601 format.
           example: 2017-02-12T13:30:00
-        summary_by:
-          $ref: '#/components/schemas/summary_by'
-        summary_field:
-          $ref: '#/components/schemas/summary_field'
         group_by:
           type: array
           items:
@@ -6206,9 +6000,6 @@ components:
 
 
             credentials and all sub accounts.
-        destination_address_country:
-          type: string
-          description: Filter results by destination address country.
         destination_address:
           type: string
           description: Filter results by destination address.
@@ -6220,15 +6011,9 @@ components:
         metadata_value:
           type: string
           description: Filter results for messages that include a metadata key containing this value. If this parameter is provided, the metadata_key parameter must also be provided.
-        source_address_country:
-          type: string
-          description: Filter results by source address country.
         source_address:
           type: string
           description: Filter results by source address.
-        delivery_report:
-          type: boolean
-          description: Filter results by delivery report.
         status_code:
           type: string
           description: Filter results by message status code.
@@ -8145,15 +7930,10 @@ components:
       title: group_by
       enum:
       - DAY
-      - DESTINATION_ADDRESS
       - DESTINATION_ADDRESS_COUNTRY
-      - FORMAT
-      - HOUR
       - METADATA_KEY
       - METADATA_VALUE
-      - MINUTE
       - MONTH
-      - SOURCE_ADDRESS
       - SOURCE_ADDRESS_COUNTRY
       - STATUS
       - STATUS_CODE
@@ -8165,16 +7945,10 @@ components:
       title: grouping
       enum:
       - DAY
-      - DELIVERY_REPORT
-      - DESTINATION_ADDRESS
       - DESTINATION_ADDRESS_COUNTRY
-      - FORMAT
-      - HOUR
       - METADATA_KEY
       - METADATA_VALUE
-      - MINUTE
       - MONTH
-      - SOURCE_ADDRESS
       - SOURCE_ADDRESS_COUNTRY
       - STATUS
       - STATUS_CODE

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -5967,6 +5967,7 @@ components:
       required:
       - end_date
       - start_date
+      - delivery_options
       type: object
       properties:
         end_date:


### PR DESCRIPTION
- Highlighting deprecated reporting endpoints:
   - `/v1/reporting/messageType/metadata/keys`
   - `/v1/reporting/async_reports`
   - `/v1/reporting/async_reports/{report_id}/data`
- Updating `GET /v1/reporting/async_reports/{report_id}` example to highlight the returned async report status in place of the deprecated `message_type`, `type`, `created_datetime`, and `last_modified_datetime`
- Updating required async report required properties to include `delivery_options`
- Deprecating:
   - Report record sorting (will use default chronological order of newest to oldest)
   - `source_address_country`, `destination_address_country` and `delivery_report` filters
   - `summary_by` and `summary_field` options in summary reports
   - Report `group`/`grouping` options:
      - `DELIVERY_REPORT`
      - `FORMAT`
      - `SOURCE_ADDRESS`
      - `DESTINATION_ADDRESS`
      - `MINUTE`
      - `HOUR`

