### PR TITLE
NEXT-249: Correcting deprecation status of short trackable links

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -18,7 +18,7 @@ info:
     name: Apache 2.0
     url: 'http://www.apache.org/licenses/LICENSE-2.0.html'
   x-logo:
-    url: 'https://developers.messagemedia.com/wp-content/themes/devportal/dist/images/MM-logo-New.png)'
+    url: 'https://theme.zdassets.com/theme_assets/11469326/eeda46f8e36425a85721c90df7aeb86541f19d9e.png'
   
   # Describe your API here, you can use GFM (https://guides.github.com/features/mastering-markdown) here
   description: |

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -3199,7 +3199,7 @@ paths:
           description: Data cannot be found
         500:
           description: System Error
-      deprecated: true
+      deprecated: false
   /v1/reporting/links/detail:
     get:
       security:
@@ -3268,7 +3268,7 @@ paths:
           description: Data cannot be found
         500:
           description: System Error
-      deprecated: true
+      deprecated: false
   /v1/webhooks/messages:
     get:
       security:


### PR DESCRIPTION
Correcting endpoints for short trackable links to not deprecated. The service remains active and there is no intention for deprecation (unlike some of the Reporting V1 endpoints this was changed alongside in #22). 

I have also included a substitute for the broken MessageMedia logo too.