### PR TITLE
NEXT-319: Change post insight report `operationId` to avoid overlap

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -981,7 +981,7 @@ paths:
         - Messaging Reports
       summary: Post insight report
       description: Create report summary containing total number of sent, received and billing units, using pre-calculated data to improve performance.
-      operationId: PostSummaryReport
+      operationId: PostInsightReport
       parameters:
         - name: start_date
           in: query


### PR DESCRIPTION
- Changing `operationId` parameter on post insight report to avoid overlap, blocking deployment of NEXT-319