### PR TITLE
NEXT-322: Metadata endpoint in `Messaging Reports`

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -1260,6 +1260,33 @@ paths:
               schema:
                 $ref: '#/components/schemas/summaryresponse'
       deprecated: false
+  /v2-preview/reporting/messages/metakeys:
+    post:
+      security:
+        - basic_auth: [ ]
+        - hmac_auth: [ ]
+      tags:
+        - Messaging Reports
+      summary: Metadata Keys
+      description: Returns a list of metadata keys.
+      operationId: PostMetadataKeys
+      parameters: []
+      requestBody:
+        description: ''
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/metakeyrequest'
+      responses:
+        200:
+          description: A list of metadata keys.
+          headers: { }
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/metakeyresponse'
+        400:
+          description: Bad Request. Check the json response for more details on what went wrong.
   '/v1/messages/{messageId}':
     get:
       security:
@@ -5388,6 +5415,19 @@ paths:
 # An object to hold reusable parts that can be used across the spec
 components:
   schemas:
+    metakeyresponse:
+      title: metakeyresponse
+      required:
+        - keys
+      properties:
+        keys:
+          type: array
+          items:
+            type: string
+          example:
+            - meta1
+            - meta2
+            - meta3
     asyncsentmessagesdetailrequest:
       title: asyncsentmessagesdetailrequest
       required:

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -661,6 +661,33 @@ servers:
 # Holds the relative paths to the individual endpoints. The path is appended to the
 # basePath in order to construct the full URL. 
 paths:
+  /v2-preview/reporting/messages/metakeys:
+    post:
+      security:
+        - basic_auth: [ ]
+        - hmac_auth: [ ]
+      tags:
+        - Messaging Reports
+      summary: Metadata Keys
+      description: Returns a list of metadata keys.
+      operationId: PostMetadataKeys
+      parameters: []
+      requestBody:
+        description: ''
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/metakeyrequest'
+      responses:
+        200:
+          description: A list of metadata keys.
+          headers: { }
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/metakeyresponse'
+        400:
+          description: Bad Request. Check the json response for more details on what went wrong.
   /v2-preview/reporting/messages/detail:
     post:
       security:
@@ -1084,33 +1111,6 @@ paths:
         404:
           description: Scheduled report not found.
       deprecated: false
-  /v2-preview/reporting/messages/metakeys:
-    post:
-      security:
-        - basic_auth: [ ]
-        - hmac_auth: [ ]
-      tags:
-        - Messaging Reports
-      summary: Metadata Keys
-      description: Returns a list of metadata keys.
-      operationId: PostMetadataKeys
-      parameters: []
-      requestBody:
-        description: ''
-        content:
-          application/json:
-            schema:
-              $ref: '#/components/schemas/metakeyrequest'
-      responses:
-        200:
-          description: A list of metadata keys.
-          headers: { }
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/metakeyresponse'
-        400:
-          description: Bad Request. Check the json response for more details on what went wrong.
   '/v1/messages/{messageId}':
     get:
       security:


### PR DESCRIPTION
- v2 Metadata Keys endpoint in `Messaging Reports` group
- Response object for metakeys