### PR TITLE
NEXT-386: Fixes to detailreport's `response`

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -5856,7 +5856,7 @@ components:
         messages:
           type: array
           items:
-            $ref: '#/components/schemas/DetailMessage'
+            $ref: '#/components/schemas/DetailReportMessageRecord'
         pagination:
           $ref: '#/components/schemas/Paginate'
     summaryresponse:
@@ -6468,31 +6468,70 @@ components:
             The subject field is used to denote subject of the MMS message and
             has a maximum size of 64 characters long
           example: New Products
-    DetailMessage:
+    DetailReportMessageRecord:
       title: Message
       required:
         - content
         - destination_number
       type: object
       properties:
+        message_id:
+          type: string
+          description: Unique ID of this message
+          format: uuid
+        format:
+          $ref: '#/components/schemas/Format'
+        timestamp:
+          type: string
+          description: Timestamp of this message
+          example: "2017-02-10T16:30:00"
+        delivered_timestamp:
+          type: string
+          description: Time that this message was delivered
+          example: "2017-02-10T16:30:00"
+        last_status_update:
+          type: string
+          description: Last time this message's status was updated
+          example: "2017-02-10T16:30:00"
+        direction:
+          $ref: '#/components/schemas/MessageDirection'
+        status:
+          $ref: '#/components/schemas/Status'
+        status_code:
+          type: number
+          description: The response code of the status
+          example: 220
+        status_description:
+          type: string
+          description: The status of the message
+          example: 'Message delivered'
+        source_address:
+          type: string
+          example: '+61490246135'
+        destination_address:
+          maxLength: 15
+          minLength: 1
+          type: string
+          description: Destination number of the message
+          example: '+6149123654'
+        destination_address_country:
+          type: string
+          description: Country of the destination address
+          example: 'AU'
         content:
           maxLength: 5000
           minLength: 1
           type: string
           description: Content of the message
           example: Hello world!
-        destination_address:
-          maxLength: 15
-          minLength: 1
+        account_id:
           type: string
-          description: Destination number of the message
-          example: '+61491570156'
-        destination_address_country:
-          type: string
-          description: Country of the destination address
-          example: 'AU'
-        format:
-          $ref: '#/components/schemas/Format'
+          description: The ID of the account
+          example: 'account_1'
+        units:
+          type: number
+          description: The amount of messages received
+          example: 1
         metadata:
           type: object
           description: >-
@@ -6511,41 +6550,6 @@ components:
           example:
             - "myKey": "myValue"
             - "anotherKey": "anotherValue"
-        source_address:
-          type: string
-          example: '+61491570156'
-        message_id:
-          type: string
-          description: Unique ID of this message
-          format: uuid
-        status:
-          $ref: '#/components/schemas/Status'
-        timestamp:
-          type: string
-          description: Timestamp of this message
-          example: "2017-02-10T16:30:00"
-        delivered_timestamp:
-          type: string
-          description: Time that this message was delivered
-          example: "2017-02-10T16:30:00"
-        last_status_update:
-          type: string
-          description: Last time this message's status was updated
-          example: "2017-02-10T16:30:00"
-        direction:
-          $ref: '#/components/schemas/MessageDirection'
-        account_id:
-          type: string
-          description: The ID of the account
-          example: 'messagingxyz_YNV_0001'
-        units:
-          type: number
-          description: The amount of messages received
-          example: 1
-        status_description:
-          type: string
-          description: The status of the message
-          example: 'Message delivered!'
     Sendmessagesresponse:
       title: Sendmessagesresponse
       type: object

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -6470,9 +6470,6 @@ components:
           example: New Products
     DetailReportMessageRecord:
       title: Message
-      required:
-        - content
-        - destination_number
       type: object
       properties:
         message_id:

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -5856,7 +5856,7 @@ components:
         messages:
           type: array
           items:
-            $ref: '#/components/schemas/Message'
+            $ref: '#/components/schemas/DetailMessage'
         pagination:
           $ref: '#/components/schemas/Paginate'
     summaryresponse:
@@ -6468,6 +6468,68 @@ components:
             The subject field is used to denote subject of the MMS message and
             has a maximum size of 64 characters long
           example: New Products
+    DetailMessage:
+      title: Message
+      required:
+        - content
+        - destination_number
+      type: object
+      properties:
+        content:
+          maxLength: 5000
+          minLength: 1
+          type: string
+          description: Content of the message
+          example: Hello world!
+        destination_address:
+          maxLength: 15
+          minLength: 1
+          type: string
+          description: Destination number of the message
+          example: '+61491570156'
+        format:
+          $ref: '#/components/schemas/Format'
+        metadata:
+          type: object
+          description: >-
+            Metadata for the message specified as a set of key value pairs, each
+            key can be up to 100 characters long and each value can be up to 256
+            characters long
+
+            ```
+
+            {
+               "myKey": "myValue",
+               "anotherKey": "anotherValue"
+            }
+
+            ```
+          example:
+            - "myKey": "myValue"
+            - "anotherKey": "anotherValue"
+        source_address:
+          type: string
+          example: '+61491570156'
+        message_id:
+          type: string
+          description: Unique ID of this message
+          format: uuid
+        status:
+          $ref: '#/components/schemas/Status'
+        timestamp:
+          type: string
+          description: Timestamp of this message
+          example: "2017-02-10T16:30:00"
+        delivered_timestamp:
+          type: string
+          description: Time that this message was delivered
+          example: "2017-02-10T16:30:00"
+        last_status_update:
+          type: string
+          description: Last time this message's status was updated
+          example: "2017-02-10T16:30:00"
+        direction:
+          $ref: '#/components/schemas/MessageDirection'
     Sendmessagesresponse:
       title: Sendmessagesresponse
       type: object

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -6487,6 +6487,10 @@ components:
           type: string
           description: Destination number of the message
           example: '+61491570156'
+        destination_address_country:
+          type: string
+          description: Country of the destination address
+          example: 'AU'
         format:
           $ref: '#/components/schemas/Format'
         metadata:
@@ -6530,6 +6534,18 @@ components:
           example: "2017-02-10T16:30:00"
         direction:
           $ref: '#/components/schemas/MessageDirection'
+        account_id:
+          type: string
+          description: The ID of the account
+          example: 'messagingxyz_YNV_0001'
+        units:
+          type: number
+          description: The amount of messages received
+          example: 1
+        status_description:
+          type: string
+          description: The status of the message
+          example: 'Message delivered!'
     Sendmessagesresponse:
       title: Sendmessagesresponse
       type: object


### PR DESCRIPTION
Fixing DetailReport's response as it omitted a few fields present in the application.

Created a new DetailMessage schema for use in DetailReport including the new fields (timestamp, direction)