### PR TITLE
NEXT-386: Fixes to async fields and summary report responses

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -5266,6 +5266,24 @@ components:
         report_type:
           type: string
           example: detail
+        metadata:
+          type: object
+          description: >-
+            Metadata for the message specified as a set of key value pairs, each
+            key can be up to 100 characters long and each value can be up to 256
+            characters long
+
+            ```
+
+            {
+               "myKey": "myValue",
+               "anotherKey": "anotherValue"
+            }
+
+            ```
+          example:
+            - "myKey": "myValue"
+            - "anotherKey": "anotherValue"
     scheduleddetailrequest:
       title: scheduleddetailrequest
       type: object
@@ -5416,6 +5434,24 @@ components:
         report_type:
           type: string
           example: detail
+        metadata:
+          type: object
+          description: >-
+            Metadata for the message specified as a set of key value pairs, each
+            key can be up to 100 characters long and each value can be up to 256
+            characters long
+
+            ```
+
+            {
+               "myKey": "myValue",
+               "anotherKey": "anotherValue"
+            }
+
+            ```
+          example:
+            - "myKey": "myValue"
+            - "anotherKey": "anotherValue"
     scheduledsummaryrequest:
       title: scheduledsummaryrequest
       type: object

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -5247,6 +5247,7 @@ components:
       required:
         - label
         - schedule
+        - report
       properties:
         label:
           type: string
@@ -5256,6 +5257,15 @@ components:
           $ref: '#/components/schemas/schedule'
         report:
           $ref: '#/components/schemas/scheduleddetailrequest'
+        scheduled_report_id:
+          type: string
+          example: "43928f76-c381-4943-8619-f10460005898"
+          description: The ID of the scheduled report.
+        message_type:
+          $ref: '#/components/schemas/MessageDirection'
+        report_type:
+          type: string
+          example: detail
     scheduleddetailrequest:
       title: scheduleddetailrequest
       type: object
@@ -5387,6 +5397,7 @@ components:
       required:
         - label
         - schedule
+        - report
       properties:
         label:
           type: string
@@ -5396,6 +5407,15 @@ components:
           $ref: '#/components/schemas/schedule'
         report:
           $ref: '#/components/schemas/scheduledsummaryrequest'
+        scheduled_report_id:
+          type: string
+          example: "43928f76-c381-4943-8619-f10460005898"
+          description: The ID of the scheduled report.
+        message_type:
+          $ref: '#/components/schemas/MessageDirection'
+        report_type:
+          type: string
+          example: detail
     scheduledsummaryrequest:
       title: scheduledsummaryrequest
       type: object
@@ -5847,7 +5867,7 @@ components:
           type: array
           items:
             type: string
-            example: id, content, meta1
+            example: [id, content, meta1]
           description: An array of fields to be retrieved.
     detailresponse:
       title: detailresponse


### PR DESCRIPTION
Fixes to asyncfields and summaryreport's responses.

Adding 'report' as a required field, wrapping a string as an array, and expanding some schemas with missing fields.