### PR TITLE
Comment the failing Slack notification

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,13 +29,13 @@ jobs:
         npm run build
         npm test
         npm run gh-pages
-    - name: Slack Notification
-      uses: rtCamp/action-slack-notify@v2.0.0
-      env:
-        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-        SLACK_USERNAME: "doc_bot"
-        SLACK_ICON_EMOJI: ":robot:"
-        SLACK_TITLE: "New production version of documentation deployed!" 	
+    # - name: Slack Notification
+    #   uses: rtCamp/action-slack-notify@v2.0.0
+    #   env:
+    #     SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+    #     SLACK_USERNAME: "doc_bot"
+    #     SLACK_ICON_EMOJI: ":robot:"
+    #     SLACK_TITLE: "New production version of documentation deployed!" 	
     # Runs a single command using the runners shell
     #- name: Run a one-line script
     #  run: echo Hello, world!


### PR DESCRIPTION
This Slack notification has not been used for a long time and sees misleading build results with failures due to a missing Slack webhook secret. Commenting this removes this as an error but could be reinstated by an owning team.