### PR TITLE
Contacts Fix Channel type example

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -9692,7 +9692,7 @@ components:
         type:
           type: string
           description: Contact channel type
-          example: PHONE
+          example: SMS
           enum:
             - SMS
             - WHATSAPP
@@ -9795,7 +9795,7 @@ components:
         type:
           type: string
           description: Contact channel type
-          example: PHONE
+          example: SMS
           enum:
             - SMS
             - WHATSAPP
@@ -10018,7 +10018,7 @@ components:
         type:
           type: string
           description: Contact channel type
-          example: PHONE
+          example: SMS
           enum:
             - SMS
             - WHATSAPP
@@ -10206,7 +10206,7 @@ components:
           items:
             type: string
             enum:
-              - PHONE
+              - SMS
               - WHATSAPP
               - GBM
               - INSTAGRAM


### PR DESCRIPTION
Fix Channel types example. Default value should be SMS instead of PHONE